### PR TITLE
fix: preventing double click on reset password button

### DIFF
--- a/src/UI/ForgotPassword.js
+++ b/src/UI/ForgotPassword.js
@@ -22,8 +22,17 @@ function ForgotPassword(props) {
   const setNotification = useNotification()
   const emailForm = useRef()
 
+  const submitBtn = useRef()
+
+  const onBtnClick = (e) => {
+    if (submitBtn.current) {
+      submitBtn.current.setAttribute('disabled', 'disabled')
+    }
+  }
+
   const handleSubmit = async (e) => {
     e.preventDefault()
+    onBtnClick()
     const form = new FormData(emailForm.current)
     const email = form.get('email')
 
@@ -66,7 +75,9 @@ function ForgotPassword(props) {
           <Label htmlFor="email">Email</Label>
           <InputField type="email" name="email" id="email" required />
         </InputBox>
-        <SubmitBtn type="submit">Reset</SubmitBtn>
+        <SubmitBtn type="submit" ref={submitBtn}>
+          Reset
+        </SubmitBtn>
       </Form>
     </FormContainer>
   )


### PR DESCRIPTION
Signed-off-by: RomanStepanyan <stepik10@gmail.com>

# Summary of Changes

Changes have been made to prevent double-clicking the password reset button and making it impossible to send a double invitation to a user.

# Related Issues

N/A

# Pull Request Checklist

This is just a reminder about the most common mistakes. Please make sure that you tick all _appropriate_ boxes. But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this).
- [ ] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components.
- [ ] Added **tests** for changed code (run `scripts/preflight` to run tests and check code style).
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code and new or modified features.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

_PR template adapted from the Python attrs project._
